### PR TITLE
Fixed imagestream name so buildconfig can start

### DIFF
--- a/alpha/nodejs-ex-k/templates/buildconfig.yaml
+++ b/alpha/nodejs-ex-k/templates/buildconfig.yaml
@@ -24,7 +24,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: nodejs-ex:latest
+      name: nodejs-example:latest
   triggers:
   - type: ImageChange
   - type: ConfigChange


### PR DESCRIPTION
This fixes the issue with buildconfig not starting since there isn't any imagestream matching the output image:
https://github.com/redhat-developer/redhat-helm-charts/blob/master/alpha/nodejs-ex-k/templates/buildconfig.yaml#L27