### PR TITLE
defaulting build.uri, created values.schema.json, added Quarkus label

### DIFF
--- a/alpha/quarkus-chart/Chart.yaml
+++ b/alpha/quarkus-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: quarkus
-version: 0.0.1
+version: 0.0.2
 description: A Helm chart to build and deploy Quarkus applications
 keywords:
   - runtimes

--- a/alpha/quarkus-chart/README.md
+++ b/alpha/quarkus-chart/README.md
@@ -15,16 +15,6 @@ build:
 and apply by passing `--values $VALUES_FILE`.
 
 ## Values
-This section describes the Values used to configure this chart.
-
-### Required Values 
-Below shows the required values to install this chart.
-
-| Value | Description | Default | Additional Information |
-| ----- | ----------- | ------- | ---------------------- |
-| `build.uri` | Git URI that references your git repo | - | **REQUIRED** |
-
-### All Values
 Below is a table of each value used to configure this chart.
 
 | Value | Description | Default | Additional Information |
@@ -32,8 +22,8 @@ Below is a table of each value used to configure this chart.
 | `image.name` | Name of the image you want to build/deploy | Defaults to the Helm release name. | The chart will create/reference an [ImageStream](https://docs.openshift.com/container-platform/4.6/openshift_images/image-streams-manage.html) based on this value. |
 | `image.tag` | Tag that you want to build/deploy | `latest` | The chart will create/reference an [ImageStreamTag](https://docs.openshift.com/container-platform/4.6/openshift_images/image-streams-manage.html#images-using-imagestream-tags_image-streams-managing) based on the name provided |
 | `build.enabled` | Determines if build-related resources should be created. | `true` | Set this to `false` if you want to deploy a previously built image. Leave this set to `true` if you want to build and deploy a new image. |
-| `build.uri` | Git URI that references your git repo | - | **REQUIRED** |
-| `build.ref` | Git ref containing the application you want to build | master | - |
+| `build.uri` | Git URI that references your git repo | https://github.com/deweya/quarkus-getting-started | This value defaults to a sample application. Be sure to override this if you want to build and deploy your own application. |
+| `build.ref` | Git ref containing the application you want to build | main | - |
 | `build.contextDir` | The sub-directory where the application source code exists | - | - |
 | `build.mode` | Determines whether the Quarkus mode should be set to `jvm` or `native` | `jvm` | Options: `jvm` or `native` |
 | `build.jvm.imageStreamTag.name` | The ImageStreamTag name of the desired builder image | `java:11` | Only has an effect if `build.mode` is set to `jvm` |

--- a/alpha/quarkus-chart/README.md
+++ b/alpha/quarkus-chart/README.md
@@ -22,7 +22,7 @@ Below is a table of each value used to configure this chart.
 | `image.name` | Name of the image you want to build/deploy | Defaults to the Helm release name. | The chart will create/reference an [ImageStream](https://docs.openshift.com/container-platform/4.6/openshift_images/image-streams-manage.html) based on this value. |
 | `image.tag` | Tag that you want to build/deploy | `latest` | The chart will create/reference an [ImageStreamTag](https://docs.openshift.com/container-platform/4.6/openshift_images/image-streams-manage.html#images-using-imagestream-tags_image-streams-managing) based on the name provided |
 | `build.enabled` | Determines if build-related resources should be created. | `true` | Set this to `false` if you want to deploy a previously built image. Leave this set to `true` if you want to build and deploy a new image. |
-| `build.uri` | Git URI that references your git repo | https://github.com/deweya/quarkus-getting-started | This value defaults to a sample application. Be sure to override this if you want to build and deploy your own application. |
+| `build.uri` | Git URI that references your git repo | https://github.com/redhat-developer-helm-quickstarts/quarkus-getting-started | This value defaults to a sample application. Be sure to override this if you want to build and deploy your own application. |
 | `build.ref` | Git ref containing the application you want to build | main | - |
 | `build.contextDir` | The sub-directory where the application source code exists | - | - |
 | `build.mode` | Determines whether the Quarkus mode should be set to `jvm` or `native` | `jvm` | Options: `jvm` or `native` |

--- a/alpha/quarkus-chart/templates/_helpers.tpl
+++ b/alpha/quarkus-chart/templates/_helpers.tpl
@@ -9,6 +9,7 @@ helm.sh/chart: {{ .Chart.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.openshift.io/runtime: quarkus
 {{- end }}
 
 {{- define "quarkus.selectorLabels" -}}

--- a/alpha/quarkus-chart/templates/buildconfig.yaml
+++ b/alpha/quarkus-chart/templates/buildconfig.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     type: Git
     git:
-      uri: {{ required "value 'build.uri' is required" .Values.build.uri }}
+      uri: {{ .Values.build.uri }}
       ref: {{ .Values.build.ref }}
 {{- if .Values.build.contextDir }}
     contextDir: {{ .Values.build.contextDir }}

--- a/alpha/quarkus-chart/values.schema.json
+++ b/alpha/quarkus-chart/values.schema.json
@@ -1,0 +1,225 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "properties": {
+        "image": {
+            "type": "object",
+            "description": "Defines the image you want to build/deploy",
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "description": "Name of the image you want to build/deploy. Defaults to the release name."
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "Tag that you want to build/deploy"
+                }
+            }
+        },
+        "build": {
+            "type": "object",
+            "description": "Values related to the build",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable the OCP Build"
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "URI of GitHub repository"
+                },
+                "ref": {
+                    "type": "string",
+                    "description": "Git ref"
+                },
+                "contextDir": {
+                    "type": ["string", "null"],
+                    "description": "Context directory within your Git repo to use as the root for the build"
+                },
+                "mode": {
+                    "type": "string",
+                    "description": "Determines if Quarkus should be built in jvm or native mode"
+                },
+                "jvm": {
+                    "type": "object",
+                    "description": "Values related to a jvm mode build",
+                    "properties": {
+                        "imageStreamTag": {
+                            "type": "object",
+                            "description": "Values related to the s2i builder's ImageStreamTag",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the ImageStreamTag"
+                                },
+                                "useReleaseNamespace": {
+                                    "type": "boolean",
+                                    "description": "Determines if the ImageStreamTag is in the namespace you are releasing to"
+                                },
+                                "namespace": {
+                                    "type": "string",
+                                    "description": "The namespace that contains the ImageStreamTag"
+                                }
+                            }
+                        }
+                    }
+                },
+                "native": {
+                    "type": "object",
+                    "description": "Values related to a native mode build",
+                    "properties": {
+                        "useDefaultDockerfile": {
+                            "type": "boolean",
+                            "description": "Determines if the default Dockerfile should be automatically provided as a build input. Set this to false if you want to provide your own Dockerfile in Git."
+                        },
+                        "dockerfilePath": {
+                            "type": "string",
+                            "description": "The path to your Dockerfile, if providing your own from Git"
+                        }
+                    }
+                },
+                "pullSecret": {
+                    "type": ["string", "null"],
+                    "description": "The image pull secret. More information: https://docs.openshift.com/container-platform/4.6/openshift_images/managing_images/using-image-pull-secrets.html"
+                },
+                "env": {
+                    "type": ["array", "null"],
+                    "description": "Freeform env field. More information: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/"
+                },
+                "resources": {
+                    "type": ["object", "null"],
+                    "description": "Freeform resources field. More information: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                }
+            }
+        },
+        "deploy": {
+            "type": "object",
+            "description": "Values related to the deployment of your application",
+            "properties": {
+                "replicas": {
+                    "type": "integer",
+                    "description": "Number of pod replicas to deploy"
+                },
+                "resources": {
+                    "type": ["object", "null"],
+                    "description": "Freeform resources field. More information: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                },
+                "serviceType": {
+                    "type": "string",
+                    "description": "The type of service to create. More information: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
+                },
+                "ports": {
+                    "type": "array",
+                    "description": "Freeform service ports field. More information: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service"
+                },
+                "route": {
+                    "type": "object",
+                    "description": "Values for creating an OCP route",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Determines if the route should be created"
+                        },
+                        "targetPort": {
+                            "type": "string",
+                            "description": "The port on pods this route points to"
+                        },
+                        "tls": {
+                            "type": "object",
+                            "description": "Values for configuring TLS on an OCP route. More information: https://docs.openshift.com/container-platform/4.6/networking/routes/secured-routes.html",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Determines if TLS should be enabled"
+                                },
+                                "termination": {
+                                    "type": "string",
+                                    "description": "Indicates the termination type"
+                                },
+                                "insecureEdgeTerminationPolicy": {
+                                    "type": "string",
+                                    "description": "Indicates the desired behavior for insecure connections"
+                                },
+                                "key": {
+                                    "type": ["string", "null"],
+                                    "description": "Key file contents"
+                                },
+                                "caCertificate": {
+                                    "type": ["string", "null"],
+                                    "description": "Certificate authority certificate contents"
+                                },
+                                "certificate": {
+                                    "type": ["string", "null"],
+                                    "description": "Certificate contents"
+                                },
+                                "destinationCACertificate": {
+                                    "type": ["string", "null"],
+                                    "description": "Contents of the CA certificate of the final destination"
+                                }
+                            }
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": ["object", "null"],
+                    "description": "Freeform livenessProbe field. More information: https://docs.openshift.com/container-platform/4.6/applications/application-health.html#application-health-about_application-health"
+                },
+                "readinessProbe": {
+                    "type": ["object", "null"],
+                    "description": "Freeform readinessProbe field. More information: https://docs.openshift.com/container-platform/4.6/applications/application-health.html#application-health-about_application-health"
+                },
+                "env": {
+                    "type": ["array", "null"],
+                    "description": "Freeform env field. More information: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/"
+                },
+                "envFrom": {
+                    "type": ["array", "null"],
+                    "description": "Freeform envFrom field. More information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables"
+                },
+                "applicationProperties": {
+                    "type": "object",
+                    "description": "Values for externalizing an application.properties file",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Determines if the application.properties file should be externalized in a ConfigMap"
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The location to mount the properties file to"
+                        },
+                        "properties": {
+                            "type": ["string", "null"],
+                            "description": "application.properties file contents"
+                        }
+                    }
+                },
+                "volumeMounts": {
+                    "type": ["array", "null"],
+                    "description": "Freeform volumeMounts field. More information: https://kubernetes.io/docs/concepts/storage/volumes/"
+                },
+                "volumes": {
+                    "type": ["array", "null"],
+                    "description": "Freeform volumes field. More information: https://kubernetes.io/docs/concepts/storage/volumes/"
+                },
+                "initContainers": {
+                    "type": ["array", "null"],
+                    "description": "Freeform initContainers field. More information: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
+                },
+                "extraContainers": {
+                    "type": ["array", "null"],
+                    "description": "Adds extra containers to your pod, provided as a list of pod templates. More information: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates"
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "description": "Values that should be global across parent and dependent Helm charts",
+            "properties": {
+                "nameOverride": {
+                    "type": ["string", "null"],
+                    "description": "Overrides the release name. Impacts the image name (if image.name is left blank) and impacts the name of created OCP resources"
+                }
+            }
+        }
+    }
+ }

--- a/alpha/quarkus-chart/values.yaml
+++ b/alpha/quarkus-chart/values.yaml
@@ -12,7 +12,7 @@ build:
   enabled: true
 
   ## Git URI, Ref, and ContextDir
-  uri: https://github.com/deweya/quarkus-getting-started
+  uri: https://github.com/redhat-developer-helm-quickstarts/quarkus-getting-started
   ref: main
   contextDir:
 

--- a/alpha/quarkus-chart/values.yaml
+++ b/alpha/quarkus-chart/values.yaml
@@ -11,9 +11,9 @@ build:
   ## Set this to false if you just want to deploy a previously built image.
   enabled: true
 
-  ## Git URI (REQUIRED), Ref, and ContextDir
-  uri:
-  ref: master
+  ## Git URI, Ref, and ContextDir
+  uri: https://github.com/deweya/quarkus-getting-started
+  ref: main
   contextDir:
 
   ## Options: jvm or native


### PR DESCRIPTION
This allows users to try out the Quarkus Helm chart without needing to provide their own build.uri. All they need to do is run `helm install` to see the results.

This defaults `build.uri` to a sample getting-started application. I copied the getting-started folder from quarkusio's quickstarts into my own repo for now - https://github.com/deweya/quarkus-getting-started. We can't use the upstream quickstart repo because this would require defaulting `build.contextDir` to `getting-started`, which might be confusing to users.

I also had to change the default `build.ref` to `main`.

And, I also bumped the chart version since this makes a change to default values.

@sbose78 @sabre1041 

---

Update: Added `values.schema.json` and the `app.openshift.io/runtime=quarkus` label