### PR TITLE
Fix repo url in index.yaml and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ The repository has been configured to serve the static helm index and chart file
 
 ```
 
-$ helm repo add redhat-charts https://redhat-developer.github.com/redhat-helm-charts
+$ helm repo add redhat-charts https://redhat-developer.github.io/redhat-helm-charts
 "redhat-charts" has been added to your repositories
 
 $ helm repo list 
 NAME           	URL                               
-redhat-charts	https://redhat-developer.github.com/redhat-helm-charts  
+redhat-charts	https://redhat-developer.github.io/redhat-helm-charts  
 
 ```
 

--- a/index.yaml
+++ b/index.yaml
@@ -34,7 +34,7 @@ entries:
     name: ibm-b2bi-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-b2bi-prod-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-b2bi-prod-2.0.0.tgz
     version: 2.0.0
   ibm-cpq-prod:
   - apiVersion: v2
@@ -82,7 +82,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-4.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-4.0.1.tgz
     version: 4.0.1
   - apiVersion: v2
     appVersion: 10.0.0.12
@@ -123,7 +123,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-4.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-4.0.0.tgz
     version: 4.0.0
   - apiVersion: v2
     appVersion: 10.0.0.10
@@ -164,7 +164,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-3.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-3.1.0.tgz
     version: 3.1.0
   ibm-mongodb-enterprise-helm:
   - apiVersion: v2
@@ -188,7 +188,7 @@ entries:
     - name: IBM
     name: ibm-mongodb-enterprise-helm
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.1.0.tgz
     version: 0.1.0
   ibm-object-storage-plugin:
   - apiVersion: v2
@@ -223,7 +223,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.7.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.7.tgz
     version: 2.0.7
   - apiVersion: v2
     appVersion: 2.0.4
@@ -257,7 +257,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.4.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.4.tgz
     version: 2.0.4
   - apiVersion: v2
     appVersion: 2.0.0
@@ -291,7 +291,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
     version: 2.0.0
   ibm-oms-ent-prod:
   - apiVersion: v2
@@ -325,7 +325,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-6.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-6.0.0.tgz
     version: 6.0.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -363,7 +363,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.1.tgz
     version: 5.1.1
   - apiVersion: v2
     appVersion: 10.0.0
@@ -401,7 +401,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.0.tgz
     version: 5.1.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -438,7 +438,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
     version: 5.0.0
   ibm-oms-pro-prod:
   - apiVersion: v2
@@ -472,7 +472,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-6.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-6.0.0.tgz
     version: 6.0.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -510,7 +510,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.1.tgz
     version: 5.1.1
   - apiVersion: v2
     appVersion: 10.0.0
@@ -548,7 +548,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.0.tgz
     version: 5.1.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -585,7 +585,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
     version: 5.0.0
   ibm-operator-catalog-enablement:
   - apiVersion: v2
@@ -615,7 +615,7 @@ entries:
     name: ibm-operator-catalog-enablement
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v2
     appVersion: 1.0.0
@@ -647,7 +647,7 @@ entries:
     name: ibm-operator-catalog-enablement
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
     version: 1.0.0
   ibm-sfg-prod:
   - apiVersion: v2
@@ -683,7 +683,7 @@ entries:
     name: ibm-sfg-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-sfg-prod-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-sfg-prod-2.0.0.tgz
     version: 2.0.0
   nodejs:
   - apiVersion: v2
@@ -695,7 +695,7 @@ entries:
     - nodejs
     name: nodejs
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-0.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-0.0.1.tgz
     version: 0.0.1
   nodejs-ex-k:
   - apiVersion: v2
@@ -706,7 +706,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 1.16.0
@@ -716,7 +716,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 1.16.0
@@ -726,7 +726,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
     version: 0.1.1
   quarkus:
   - apiVersion: v2
@@ -738,7 +738,7 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.3.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v2
     created: "2021-04-05T23:12:21.911063468-07:00"
@@ -749,7 +749,7 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.2.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v2
     created: "2021-04-05T23:12:21.91011321-07:00"
@@ -760,6 +760,6 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.1.tgz
     version: 0.0.1
 generated: "2021-04-05T23:12:21.617025225-07:00"


### PR DESCRIPTION
It seems like the repo url was update to `https://redhat-developer.github.io/redhat-helm-charts` while the same was not reflected in  index.yaml and the README which caused helm to fail while finding the related charts. 
Update both readme and index.yaml and tested with helm.