### PR TITLE
Fix URLs of redhat charts in index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -29,7 +29,7 @@ entries:
     name: ibm-b2bi-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-b2bi-prod-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-b2bi-prod-2.0.0.tgz
     version: 2.0.0
   ibm-cpq-prod:
   - apiVersion: v2
@@ -67,7 +67,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-4.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-4.0.1.tgz
     version: 4.0.1
   - apiVersion: v2
     appVersion: 10.0.0.12
@@ -98,7 +98,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-4.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-4.0.0.tgz
     version: 4.0.0
   - apiVersion: v2
     appVersion: 10.0.0.10
@@ -129,7 +129,7 @@ entries:
     - name: IBM
     name: ibm-cpq-prod
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-cpq-prod-3.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-cpq-prod-3.1.0.tgz
     version: 3.1.0
   ibm-mongodb-enterprise-helm:
   - apiVersion: v2
@@ -149,7 +149,7 @@ entries:
     - name: IBM
     name: ibm-mongodb-enterprise-helm
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.2.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-mongodb-enterprise-helm-0.2.0.tgz
     version: 0.2.0
   ibm-object-storage-plugin:
   - apiVersion: v2
@@ -171,7 +171,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.7.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.7.tgz
     version: 2.0.7
   - apiVersion: v2
     appVersion: 2.0.4
@@ -192,7 +192,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.4.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.4.tgz
     version: 2.0.4
   - apiVersion: v2
     appVersion: 2.0.0
@@ -213,7 +213,7 @@ entries:
       name: IBM
     name: ibm-object-storage-plugin
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-object-storage-plugin-2.0.0.tgz
     version: 2.0.0
   ibm-oms-ent-prod:
   - apiVersion: v2
@@ -247,7 +247,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-6.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-6.0.0.tgz
     version: 6.0.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -280,7 +280,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.1.tgz
     version: 5.1.1
   - apiVersion: v2
     appVersion: 10.0.0
@@ -313,7 +313,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.1.0.tgz
     version: 5.1.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -345,7 +345,7 @@ entries:
     name: ibm-oms-ent-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-ent-prod-5.0.0.tgz
     version: 5.0.0
   ibm-oms-pro-prod:
   - apiVersion: v2
@@ -379,7 +379,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-6.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-6.0.0.tgz
     version: 6.0.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -412,7 +412,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.1.tgz
     version: 5.1.1
   - apiVersion: v2
     appVersion: 10.0.0
@@ -445,7 +445,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.1.0.tgz
     version: 5.1.0
   - apiVersion: v2
     appVersion: 10.0.0
@@ -477,7 +477,7 @@ entries:
     name: ibm-oms-pro-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-oms-pro-prod-5.0.0.tgz
     version: 5.0.0
   ibm-operator-catalog-enablement:
   - apiVersion: v2
@@ -502,7 +502,7 @@ entries:
     name: ibm-operator-catalog-enablement
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.1.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v2
     appVersion: 1.0.0
@@ -525,7 +525,7 @@ entries:
     name: ibm-operator-catalog-enablement
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-operator-catalog-enablement-1.0.0.tgz
     version: 1.0.0
   ibm-sfg-prod:
   - apiVersion: v2
@@ -556,7 +556,7 @@ entries:
     name: ibm-sfg-prod
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/ibm-sfg-prod-2.0.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/ibm-sfg-prod-2.0.0.tgz
     version: 2.0.0
   nodejs:
   - apiVersion: v2
@@ -568,7 +568,7 @@ entries:
     - nodejs
     name: nodejs
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-0.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-0.0.1.tgz
     version: 0.0.1
   nodejs-ex-k:
   - apiVersion: v2
@@ -579,7 +579,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 1.16.0
@@ -589,7 +589,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 1.16.0
@@ -599,7 +599,7 @@ entries:
     name: nodejs-ex-k
     type: application
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/nodejs-ex-k-0.1.1.tgz
     version: 0.1.1
   quarkus:
   - apiVersion: v2
@@ -611,7 +611,7 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.3.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v2
     created: "2021-05-10T06:49:14.407997511-04:00"
@@ -622,7 +622,7 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.2.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v2
     created: "2021-05-10T06:49:14.406859443-04:00"
@@ -633,6 +633,6 @@ entries:
     - quarkus
     name: quarkus
     urls:
-    - https://redhat-developer.github.com/redhat-helm-charts/charts/quarkus-0.0.1.tgz
+    - https://redhat-developer.github.io/redhat-helm-charts/charts/quarkus-0.0.1.tgz
     version: 0.0.1
 generated: "2021-05-10T06:49:14.059767661-04:00"


### PR DESCRIPTION
Currently the official repo is `https://redhat-developer.github.io/redhat-helm-charts` however the `index.yaml` contains references to charts at former `https://redhat-developer.github.com/redhat-helm-charts/charts/` repo, which are invalid.

This PR fixes the chart URLs in index.yaml to be based on the new `https://redhat-developer.github.io/redhat-helm-charts/charts/` repo

Fixes https://github.com/redhat-developer/redhat-helm-charts/issues/61