### PR TITLE
Correct ImageStream name

### DIFF
--- a/alpha/quarkus-chart/templates/buildconfig.yaml
+++ b/alpha/quarkus-chart/templates/buildconfig.yaml
@@ -24,7 +24,7 @@ spec:
 {{- end }}
 {{- if and .Values.build.native.useDefaultDockerfile (eq .Values.build.mode "native") }}
     dockerfile: |-
-      FROM registry.redhat.io/quarkus/mandrel-20-rhel8 AS builder
+      FROM registry.redhat.io/quarkus/mandrel-22-rhel8 AS builder
       USER root
       WORKDIR /build/
       COPY . /build/

--- a/alpha/quarkus-chart/templates/imagestream.yaml
+++ b/alpha/quarkus-chart/templates/imagestream.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: {{ include "quarkus.name" . }}
+  name: {{ include "quarkus.imageName" . }}
   labels:
     {{- include "quarkus.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
The ImageStream resource name did not use the `imageName` helper template, so setting a name different to the release would not build properly since the build had no valid ImageStream to push to.